### PR TITLE
quote_display stashed in /scenes for use

### DIFF
--- a/scenes/menus/main_menu.tscn
+++ b/scenes/menus/main_menu.tscn
@@ -145,6 +145,7 @@ position = Vector2(0, 137)
 scale = Vector2(0.68, 0.960002)
 
 [node name="CollisionShape2D" type="CollisionPolygon2D" parent="EyeballRoot/StaticBody2D"]
+visible = false
 position = Vector2(14, 20)
 scale = Vector2(1.17194, 1.17194)
 polygon = PackedVector2Array(-13, -16, -111, -18, -253, -44, -316, -77, -366, -122, -301, -206, -226, -227, -120, -248, 13, -254, 126, -248, 252, -217, 323, -176, 335, -124, 290, -77, 207, -44, 76, -15, -11, -15, -11, 23, 198, 10, 200, 10, 437, -7, 508, -75, 374, -267, 33, -333, -442, -267, -529, -106, -418, 32, -14, 25)

--- a/scenes/quote_display.tscn
+++ b/scenes/quote_display.tscn
@@ -1,0 +1,82 @@
+[gd_scene load_steps=9 format=3 uid="uid://djx6t0onmy626"]
+
+[ext_resource type="FontFile" uid="uid://dwue47eggesu0" path="res://assets/fonts/Kingthings Willow.ttf" id="1_jr3va"]
+[ext_resource type="Script" path="res://scripts/menu_logic/quote_display.gd" id="1_nnuc1"]
+[ext_resource type="FontFile" uid="uid://disbfv4nbsndf" path="res://assets/fonts/Kingthings Willowless.ttf" id="2_hkmv4"]
+
+[sub_resource type="CanvasTexture" id="CanvasTexture_52o1x"]
+
+[sub_resource type="Theme" id="Theme_e6u7q"]
+RichTextLabel/constants/line_separation = 26
+RichTextLabel/font_sizes/italics_font_size = 36
+RichTextLabel/font_sizes/normal_font_size = 36
+RichTextLabel/fonts/italics_font = ExtResource("1_jr3va")
+RichTextLabel/fonts/normal_font = ExtResource("2_hkmv4")
+
+[sub_resource type="Animation" id="Animation_0xx8l"]
+resource_name = "fade_out"
+length = 3.0
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath(".:modulate")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(1, 3),
+"transitions": PackedFloat32Array(1, 1),
+"update": 0,
+"values": [Color(1, 1, 1, 1), Color(1, 1, 1, 0)]
+}
+
+[sub_resource type="Animation" id="Animation_awuwx"]
+resource_name = "fade_in"
+length = 2.0
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath(".:modulate")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0, 2),
+"transitions": PackedFloat32Array(1, 1),
+"update": 0,
+"values": [Color(1, 1, 1, 0), Color(1, 1, 1, 1)]
+}
+
+[sub_resource type="AnimationLibrary" id="AnimationLibrary_vt6ub"]
+_data = {
+"fade_in": SubResource("Animation_awuwx"),
+"fade_out": SubResource("Animation_0xx8l")
+}
+
+[node name="QuoteDisplay" type="MarginContainer"]
+modulate = Color(1, 1, 1, 0)
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_nnuc1")
+quote_default = "\"A summoner is defined by his summons. A wizard spends his whole life contacting the divine. Of all the great beasts of Hell, the most powerful...has gills.\"-Archmage Tolsarion, 1254 A.D"
+
+[node name="TextureRect" type="TextureRect" parent="."]
+self_modulate = Color(0, 0, 0, 1)
+layout_mode = 2
+texture = SubResource("CanvasTexture_52o1x")
+
+[node name="RichTextLabel" type="RichTextLabel" parent="."]
+custom_minimum_size = Vector2(1000, 500)
+layout_mode = 2
+size_flags_horizontal = 4
+size_flags_vertical = 4
+theme = SubResource("Theme_e6u7q")
+bbcode_enabled = true
+
+[node name="AnimationPlayer" type="AnimationPlayer" parent="."]
+libraries = {
+"": SubResource("AnimationLibrary_vt6ub")
+}
+
+[connection signal="kys" from="." to="." method="_on_kys"]

--- a/scripts/menu_logic/quote_display.gd
+++ b/scripts/menu_logic/quote_display.gd
@@ -1,0 +1,75 @@
+extends MarginContainer
+@export var quote_default: String = ""
+@export var fade_speed = 30
+@export var author_delay = 800
+@export var end_timer : int
+var num = 0
+var num2 = 0
+var words = ""
+var author = ""
+var ending: bool = false
+@onready var anim = $AnimationPlayer
+var exit : bool = false
+signal kys(anim_time)
+
+# Called when the node enters the scene tree for the first time.
+func _ready():
+	self.visible = false ####exists invisibly in scene by default
+	exit = false
+	#start(quote_default)
+	
+
+func start(the_quote, start_delay: int = 3):
+	self.visible = true
+	anim.play("fade_in")
+	await get_tree().create_timer(3).timeout
+	roll_quote(the_quote)
+	
+func _process(delta):
+	if author and words and !ending:
+		update_bbcode(words, author, delta*fade_speed * num, delta*fade_speed / 2 * num2)
+		num += 1
+		if num > author_delay:
+		
+			num2 += 1
+	elif author and words and ending and num > 0:
+	
+		update_bbcode(words, author, delta*fade_speed * num, delta*fade_speed / 2 * num2)
+		num -= 1
+		num2 = num
+	elif ending and !exit:
+		kys.emit(3)
+		
+		
+	
+	
+func update_bbcode(word, autho, length: int = 0, length2: int = 0 ):
+	$RichTextLabel.bbcode_text = str("[center][fade start=0 length=", length, "]", word, "[/fade][/center][center][fade start=0 length=", length2, "]" , autho)
+	
+
+func roll_quote(quote : String, length : int = 0, length2: int = 0, til_end: int = 10):
+	
+	
+	var split = quote.split("-") ####[quote, author]
+	words = split[0]
+	author = split[1]
+	author = str("\n - [i]", author, "[/i]")
+	$RichTextLabel.bbcode_text = str("[center][fade start=0 length=", length, "]", words, "[/fade][fade start=0 length=", length2, "]" , author, "[/center]")
+	await get_tree().create_timer(til_end).timeout
+	ending = true
+
+func re_init():
+	num = 0
+	num2 = 0
+	words = ""
+	author = ""
+	ending = false
+	exit = false
+
+func _on_kys(time):
+	exit = true
+	$RichTextLabel.clear()
+	anim.play("fade_out")
+	await get_tree().create_timer(time).timeout
+	self.visible = false
+	re_init()


### PR DESCRIPTION
Attach to any scene within a canvas layer. On ready, the display will be invisible. If given the function .start("Some Quote - Some Guy") it will parse the string into a formatted richtextlabel that fades on screen. Don't ask how it works, the hamsters running on the series of wheels lead very private lives. For convenience, when just passing .start() without any variables, the colony of hamsters automatically run a default quote (the one alex sent) to start the game. After the fade in/out, the hamsters clean up the screen and return the scene to invisibility, reinitializing themselves for the next .start("Quote - Author") call